### PR TITLE
Make uri optional in request method

### DIFF
--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -101,7 +101,7 @@ class HTTPClient extends \GuzzleHttp\Client
     /**
      * Overrides base class request method to automatically add authentication options to request.
      */
-    public function request( $method, $uri, array $options = [] )
+    public function request( $method, $uri = '', array $options = [] )
     {
         //
         // Add authentication options


### PR DESCRIPTION
GuzzleHttp\Client declares uri param as optional in request method. Latest php versions threats this as incorrect method implementation and throws exception.