### PR TITLE
Update Guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This client supports API version 1.0.
 
 ### Requirements
 The API client needs [composer](https://getcomposer.org/). For installation have a look at its [documentation](https://getcomposer.org/download/).
-Additionally, the API client needs PHP 5.6 or newer.
+Additionally, the API client needs PHP 7.2 or newer.
 
 ### Integration into your project
 Add the following to the "require" section of your project's composer.json file:

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php":               ">=5.6",
-        "guzzlehttp/guzzle": "^6"
+        "php":               ">=7.2",
+        "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
         "phpunit/phpunit": ">=5.7 <8"

--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -7,6 +7,8 @@
 
 namespace ZammadAPIClient;
 
+use Psr\Http\Message\ResponseInterface;
+
 class HTTPClient extends \GuzzleHttp\Client
 {
     private $base_url;
@@ -124,7 +126,7 @@ class HTTPClient extends \GuzzleHttp\Client
     /**
      * Overrides base class request method to automatically add authentication options to request.
      */
-    public function request( $method, $uri = '', array $options = [] )
+    public function request(string $method, $uri = '', array $options = [] ): ResponseInterface
     {
         //
         // Add authentication options


### PR DESCRIPTION
Guzzle 7 was released in June and dropped support for PHP 7.1 and below. I don't think this is a problem because all of these PHP versions are EOL.

https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md