### PR TITLE
Fix HTTPClient counter logic

### DIFF
--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -93,7 +93,7 @@ class HTTPClient extends \GuzzleHttp\Client
             ];
         }
 
-        if ( $number_of_authentication_types_given != 1 ) {
+        if ( $number_of_authentication_types_given === 0 ) {
             throw new \RuntimeException('Missing authentication options: Either give username/password, http_token or oauth2_token');
         }
 


### PR DESCRIPTION
`$number_of_authentication_types_given` can be 0 to 3 based on the passed auth credentials. This should only throw an exception if there is nothing set but continue if there are multiple credentials set.

This should fix: https://github.com/zammad/zammad-api-client-php/issues/36