### PR TITLE
Modifies tests to acknowledge Ticket API changes in #2421

### DIFF
--- a/test/ZammadAPIClient/Resource/TicketTest.php
+++ b/test/ZammadAPIClient/Resource/TicketTest.php
@@ -25,7 +25,8 @@ class TicketTest extends AbstractBaseTest
                         'body'    => 'Unit test article 1... ' . $this->getUniqueID(),
                     ],
                 ],
-                'expected_success' => true,
+                'expected_success'       => true,
+                'expected_article_count' => 1,
             ],
             // Another object with valid data.
             [
@@ -40,7 +41,8 @@ class TicketTest extends AbstractBaseTest
                         'body'    => 'Unit test article 2... ' . $this->getUniqueID(),
                     ],
                 ],
-                'expected_success' => true,
+                'expected_success'       => true,
+                'expected_article_count' => 1,
             ],
             // Missing required field 'body'.
             [
@@ -85,7 +87,8 @@ class TicketTest extends AbstractBaseTest
                     //     'body'    => 'Unit test article 6... ' . $this->getUniqueID(),
                     // ],
                 ],
-                'expected_success' => 'no_articles',
+                'expected_success'       => true,
+                'expected_article_count' => 0,
             ],
         ];
 
@@ -95,7 +98,7 @@ class TicketTest extends AbstractBaseTest
     /**
      * @dataProvider objectCreateProvider
      */
-    public function testCreate( $values, $expected_success )
+    public function testCreate( $values, $expected_success, $expected_article_count = 0 )
     {
         $object = self::getClient()->resource( $this->resource_type );
         $this->assertInstanceOf(
@@ -192,23 +195,25 @@ class TicketTest extends AbstractBaseTest
             'Articles of ticket object must be returned as array.'
         );
 
-        if($expected_success === true){
-          $this->assertCount(
-              1,
-              $articles,
-              'Ticket object must have exactly one article.'
-          );
+        $this->assertCount(
+            $expected_article_count,
+            $articles,
+            'Ticket object must have exactly one article.'
+        );
 
-          $article = array_shift($articles);
-          foreach ( $values['article'] as $field => $expected_value ) {
+        if (!$expected_article_count) {
+            return;
+        }
 
-              // Compare via value from getValue()
-              $this->assertEquals(
-                  $expected_value,
-                  $article->getValue($field),
-                  "Value of article must match expected value (field $field)."
-              );
-          }
+        $article = array_shift($articles);
+        foreach ( $values['article'] as $field => $expected_value ) {
+
+            // Compare via value from getValue()
+            $this->assertEquals(
+                $expected_value,
+                $article->getValue($field),
+                "Value of article must match expected value (field $field)."
+            );
         }
     }
 

--- a/test/ZammadAPIClient/Resource/TicketTest.php
+++ b/test/ZammadAPIClient/Resource/TicketTest.php
@@ -198,7 +198,7 @@ class TicketTest extends AbstractBaseTest
         $this->assertCount(
             $expected_article_count,
             $articles,
-            'Ticket object must have exactly one article.'
+            'Ticket object must have exactly '.$expected_article_count.' article(s).'
         );
 
         if (!$expected_article_count) {

--- a/test/ZammadAPIClient/Resource/TicketTest.php
+++ b/test/ZammadAPIClient/Resource/TicketTest.php
@@ -42,6 +42,21 @@ class TicketTest extends AbstractBaseTest
                 ],
                 'expected_success' => true,
             ],
+            // Missing required field 'body'.
+            [
+                'values' => [
+                    'group_id'    => 1,
+                    'priority_id' => 1,
+                    'state_id'    => 1,
+                    'title'       => 'Unit test ticket 2 ' . $this->getUniqueID(),
+                    'customer_id' => 1,
+                    'article'     => [
+                        'subject' => 'Unit test article 2 ' . $this->getUniqueID(),
+                        'body'    => '',
+                    ],
+                ],
+                'expected_success' => false,
+            ],
             // Missing required field 'group_id'.
             [
                 'values' => [
@@ -57,7 +72,7 @@ class TicketTest extends AbstractBaseTest
                 ],
                 'expected_success' => false,
             ],
-            // Missing article data.
+            // Allows to create a stub ticket without an article.
             [
                 'values' => [
                     'group_id'    => 1,
@@ -70,7 +85,7 @@ class TicketTest extends AbstractBaseTest
                     //     'body'    => 'Unit test article 6... ' . $this->getUniqueID(),
                     // ],
                 ],
-                'expected_success' => false,
+                'expected_success' => true,
             ],
         ];
 

--- a/test/ZammadAPIClient/Resource/TicketTest.php
+++ b/test/ZammadAPIClient/Resource/TicketTest.php
@@ -198,17 +198,17 @@ class TicketTest extends AbstractBaseTest
               $articles,
               'Ticket object must have exactly one article.'
           );
-        }
 
-        $article = array_shift($articles);
-        foreach ( $values['article'] as $field => $expected_value ) {
+          $article = array_shift($articles);
+          foreach ( $values['article'] as $field => $expected_value ) {
 
-            // Compare via value from getValue()
-            $this->assertEquals(
-                $expected_value,
-                $article->getValue($field),
-                "Value of article must match expected value (field $field)."
-            );
+              // Compare via value from getValue()
+              $this->assertEquals(
+                  $expected_value,
+                  $article->getValue($field),
+                  "Value of article must match expected value (field $field)."
+              );
+          }
         }
     }
 

--- a/test/ZammadAPIClient/Resource/TicketTest.php
+++ b/test/ZammadAPIClient/Resource/TicketTest.php
@@ -85,7 +85,7 @@ class TicketTest extends AbstractBaseTest
                     //     'body'    => 'Unit test article 6... ' . $this->getUniqueID(),
                     // ],
                 ],
-                'expected_success' => true,
+                'expected_success' => 'no_articles',
             ],
         ];
 
@@ -191,11 +191,14 @@ class TicketTest extends AbstractBaseTest
             $articles,
             'Articles of ticket object must be returned as array.'
         );
-        $this->assertCount(
-            1,
-            $articles,
-            'Ticket object must have exactly one article.'
-        );
+
+        if($expected_success === true){
+          $this->assertCount(
+              1,
+              $articles,
+              'Ticket object must have exactly one article.'
+          );
+        }
 
         $article = array_shift($articles);
         foreach ( $values['article'] as $field => $expected_value ) {


### PR DESCRIPTION
The original test always expect 1 article when ticket creation is successful. I introduced a flag to indicate if article is present or not.