### PR TITLE
Allowing injection of custom client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -44,10 +44,10 @@ class Client
      *
      * @return Object                           Client object
      */
-    public function __construct( array $options = [] )
+    public function __construct( array $options = [], HTTPClientInterface $client = null)
     {
         $this->options     = $options;
-        $this->http_client = new HTTPClient($options);
+        $this->http_client = $client ?? new HTTPClient($options);
     }
 
     /**

--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -9,7 +9,7 @@ namespace ZammadAPIClient;
 
 use Psr\Http\Message\ResponseInterface;
 
-class HTTPClient extends \GuzzleHttp\Client
+class HTTPClient extends \GuzzleHttp\Client implements HTTPClientInterface
 {
     private $base_url;
     private $authentication_options;

--- a/src/HTTPClientInterface.php
+++ b/src/HTTPClientInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZammadAPIClient;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface HTTPClientInterface
+{
+    public function request(string $method, $uri = '', array $options = []): ResponseInterface;
+}


### PR DESCRIPTION
We need to inject a different HTTP client into the zammad client in order to deal with some custom guzzle options.

This allows to add a custom http client without BC breaks.