### PR TITLE
Fix PHP 8.1 deprecation warning for NULL on_behalf_of_user

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -72,7 +72,7 @@ class Client
         $options['headers']['Content-Type'] = 'application/json; charset=utf-8';
 
         // Set "on behalf of user" header
-        if ( mb_strlen($this->on_behalf_of_user) ) {
+        if ( !empty($this->on_behalf_of_user) ) {
             $options['headers']['X-On-Behalf-Of'] = $this->on_behalf_of_user;
         }
 


### PR DESCRIPTION
Fixes #49, empty handles both null and empty string just fine