### PR TITLE
Add support for Tag: Administration scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Additionally you can have a look at the REST interface documentation of Zammad:
    * [Ticket priorities](https://docs.zammad.org/en/latest/api/ticket-priority.html)
    * [Ticket states](https://docs.zammad.org/en/latest/api/ticket-state.html)
 * [Tags](https://docs.zammad.org/en/latest/api/tags.html)
+* [Tag list](https://docs.zammad.org/en/latest/api/ticket/tags.html#administration-scope)
 
 #### Fetching a ticket's articles
 If you already have a ticket object, you can easily fetch its articles:
@@ -307,7 +308,7 @@ $client->resource( ResourceType::TICKET );
 | ORGANIZATION|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|&ndash;|&#10004;|
 | GROUP|&#10004;|&#10004;|&ndash;|&#10004;|&#10004;|&ndash;|&ndash;|&ndash;|
 | USER|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|&ndash;|&#10004;|
-| TAG|&#10004;|&ndash;|&#10004;|&ndash;|&ndash;|&#10004;|&#10004;|&ndash;|
+| TAG|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|
 
 ## Publishing
 

--- a/src/Resource/Tag.php
+++ b/src/Resource/Tag.php
@@ -13,7 +13,11 @@ class Tag extends AbstractResource
         'get'    => 'tags',
         'search' => 'tag_search?term={query}',
         'add'    => 'tags/add',
-        'remove' => 'tags/remove'
+        'remove' => 'tags/remove',
+        'all'    => 'tag_list',
+        'create' => 'tag_list',
+        'update' => 'tag_list/{object_id}',
+        'delete' => 'tag_list/{object_id}',
     ];
 
     /**


### PR DESCRIPTION
Here is a small update that allows the administration tasks for tags (all, create, update, delete)