### PR TITLE
Fix deprecation notice on PHP 8.4

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -42,11 +42,11 @@ class Client
      *                                              debug => true,
      *                                          ];
      *
-     * @param HTTPClientInterface $client       Optional, pass in custom HTTP client.
+     * @param ?HTTPClientInterface $client      Optional, pass in custom HTTP client.
      *
      * @return Object                           Client object
      */
-    public function __construct( array $options = [], HTTPClientInterface $client = null)
+    public function __construct( array $options = [], ?HTTPClientInterface $client = null)
     {
         $this->options     = $options;
         $this->http_client = $client ?? new HTTPClient($options);


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate-implicitly-nullable-types