### PR TITLE
Fix getID method to handle null values and always return a string

### DIFF
--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -177,7 +177,8 @@ abstract class AbstractResource
      */
     public function getID()
     {
-        return $this->getValue('id');
+        $value = $this->getValue('id');
+        return $value === null ? null : (string) $value;
     }
 
     /**


### PR DESCRIPTION
getID() should always return a string, but in some cases it returns an integer.