### PR TITLE
Maintenance – add ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT env

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ $client->resource( ResourceType::TICKET );
 | TAG|&#10004;|&ndash;|&#10004;|&ndash;|&ndash;|&#10004;|&#10004;|&ndash;|
 | LINK|&#10004;|&ndash;|&ndash;|&ndash;|&ndash;|&#10004;|&#10004;|&ndash;|
 
+
 ## Publishing
 
 1. Add release to [CHANGELOG.md](CHANGELOG.md)
@@ -335,3 +336,24 @@ $client->resource( ResourceType::TICKET );
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub](https://github.com/zammad/zammad-api-client-php). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+### Running tests
+
+Tests require a running Zammad instance with API access enabled. Set the following environment variables:
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL` | Yes | — | URL to Zammad (e.g. `http://localhost:3000/`) |
+| `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME` | Yes | — | Username for authentication |
+| `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD` | Yes | — | Password for authentication |
+| `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT` | No | `30` | Request timeout in seconds |
+
+**Note:** Only username/password authentication is supported for tests.
+
+```bash
+ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL="http://localhost:3000/" \
+ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME="admin@example.com" \
+ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD="test" \
+ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT=120 \
+vendor/bin/phpunit
+```

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <env name="ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL" value="https://...." />
         <env name="ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME" value="..." />
         <env name="ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD" value="..." />
+        <env name="ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT" value="30" />
         -->
     </php>
 </phpunit>

--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -136,7 +136,7 @@ class HTTPClient extends \GuzzleHttp\Client implements HTTPClientInterface
 
         // Optional: pass additional Guzzle options (e.g. headers, curl options)
         $connection_options = [];
-        if (array_key_exists('connection_options', $options) && is_array($options['connection_options'])) {
+        if (is_array($options['connection_options'] ?? null)) {
             $connection_options = $options['connection_options'];
         }
 

--- a/src/HTTPClient.php
+++ b/src/HTTPClient.php
@@ -134,14 +134,22 @@ class HTTPClient extends \GuzzleHttp\Client implements HTTPClientInterface
             $verifySsl = $options['verify'];
         }
 
+        // Optional: pass additional Guzzle options (e.g. headers, curl options)
+        $connection_options = [];
+        if (array_key_exists('connection_options', $options) && is_array($options['connection_options'])) {
+            $connection_options = $options['connection_options'];
+        }
+
         // Execute constructor of base class
-        parent::__construct([
-            'base_uri'         => $this->base_url,
-            'timeout'          => $timeout,
-            'connect_timeout'  => $timeout,
-            'debug'            => $debug,
-            'verify'           => $verifySsl,
-        ]);
+        parent::__construct(
+            [
+                'base_uri'         => $this->base_url,
+                'timeout'          => $timeout,
+                'connect_timeout'  => $timeout,
+                'debug'            => $debug,
+                'verify'           => $verifySsl,
+            ] + $connection_options
+        );
     }
 
     /**

--- a/test/ZammadAPIClient/Resource/AbstractBaseTest.php
+++ b/test/ZammadAPIClient/Resource/AbstractBaseTest.php
@@ -17,10 +17,12 @@ abstract class AbstractBaseTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        $client_timeout = getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT');
+        
         $client_config = [
-            # Set a high timeout for tests to work with slow CI.
-            'timeout' => 30,
+            'timeout' => !empty($client_timeout) ? $client_timeout : 30,
             'debug' => getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_DEBUG'),
+            'connection_options' => ['headers' => ['Connection' => 'close']],
         ];
 
         $env_keys = [


### PR DESCRIPTION
### What
Configurable request timeout for tests, Connection: close header to prevent Keep-Alive hangs, and connection_options support in the HTTP client.

### Changes
`src/HTTPClient.php`
- New connection_options key to pass arbitrary Guzzle options (headers, curl, etc.) through to the Guzzle client.
`test/.../AbstractBaseTest.php`
- `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT` — optional env variable, overrides request timeout (default: 30s).
- connection_options with Connection: close — prevents HTTP connection reuse that hangs against local Zammad instances.

`README.md`
- New ### Running tests section documenting all test env variables with a table and usage example.
phpunit.xml.dist
- Added `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT` to the documented env variables.

### How to test
Set env variables for a running Zammad instance, then:
`ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT=120 vendor/bin/phpunit`