### PR TITLE
Maintenance – Change header x on behalf of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.2.3] - 2026-06-08
+- Fixed [#64](https://github.com/zammad/zammad-api-client-php/issues/64) - Use `From` header instead of deprecated `X-On-Behalf-Of`.
+
 ## [2.2.2] - 2026-04-27
 - Fix PHP deprecation warnings.
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ If you want Zammad to execute an API call on behalf of another user than the one
 ```php
 $client->setOnBehalfOfUser('myuser');
 ```
-Any API call after above code will use this setting. If you want to return to using the user you used for authentication, call:
+This sets the `From` HTTP header. Any API call after above code will use this setting. If you want to return to using the user you used for authentication, call:
 ```php
 $client->unsetOnBehalfOfUser();
 ```

--- a/src/Client.php
+++ b/src/Client.php
@@ -73,9 +73,9 @@ class Client
         $options['headers']['Accept']       = 'application/json';
         $options['headers']['Content-Type'] = 'application/json; charset=utf-8';
 
-        // Set "on behalf of user" header
+        // Set "on behalf of user" header (X-On-Behalf-Of was deprecated in Zammad 6.5 in favor of From)
         if ( !empty($this->on_behalf_of_user) ) {
-            $options['headers']['X-On-Behalf-Of'] = $this->on_behalf_of_user;
+            $options['headers']['From'] = $this->on_behalf_of_user;
         }
 
         $http_client_response = $this->http_client->request( $method, $url, $options );

--- a/test/ZammadAPIClient/ClientTest.php
+++ b/test/ZammadAPIClient/ClientTest.php
@@ -5,10 +5,15 @@ namespace ZammadAPIClient;
 use PHPUnit\Framework\TestCase;
 
 use ZammadAPIClient\Client;
+use ZammadAPIClient\EnvConfigTrait;
+use ZammadAPIClient\HTTPClientInterface;
 use GuzzleHttp\Exception\ConnectException;
+use Psr\Http\Message\ResponseInterface;
 
 class ClientTest extends TestCase
 {
+    use EnvConfigTrait;
+
     public function testNetworkError()
     {
         // When providing a wrong URL, there must be a proper exception thrown.
@@ -20,5 +25,81 @@ class ClientTest extends TestCase
             'password' => 'nonexisting',
         ]);
         $client->get('/nonexisting');
+    }
+
+    public function testSetsFromHeaderWhenOnBehalfOfUserIsSet()
+    {
+        $client = $this->createClientWithMockHttpClient();
+        $client->setOnBehalfOfUser('testuser');
+        $client->get('tickets');
+
+        $this->assertArrayHasKey('From', $this->capturedOptions['headers']);
+        $this->assertSame('testuser', $this->capturedOptions['headers']['From']);
+    }
+
+    public function testDoesNotSetFromHeaderByDefault()
+    {
+        $client = $this->createClientWithMockHttpClient();
+        $client->get('tickets');
+
+        $this->assertArrayNotHasKey('From', $this->capturedOptions['headers']);
+    }
+
+    public function testRemovesFromHeaderAfterUnsetOnBehalfOfUser()
+    {
+        $client = $this->createClientWithMockHttpClient();
+        $client->setOnBehalfOfUser('testuser');
+        $client->unsetOnBehalfOfUser();
+        $client->get('tickets');
+
+        $this->assertArrayNotHasKey('From', $this->capturedOptions['headers']);
+    }
+
+    public function testFromHeaderAgainstZammad()
+    {
+        $client = self::createZammadClient();
+        if (!$client) {
+            $this->markTestSkipped(
+                'Zammad environment variables not set. '
+                . 'Set ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL, '
+                . 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME, '
+                . 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD.'
+            );
+        }
+
+        $client->setOnBehalfOfUser(getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME'));
+        $response = $client->get('users');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertFalse($response->hasError());
+
+        $client->unsetOnBehalfOfUser();
+        $response = $client->get('users');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertFalse($response->hasError());
+    }
+
+    private $capturedOptions = [];
+
+    private function createClientWithMockHttpClient()
+    {
+        $this->capturedOptions = [];
+
+        $mockResponse = $this->createMock(ResponseInterface::class);
+
+        $mockHttpClient = $this->createMock(HTTPClientInterface::class);
+        $mockHttpClient
+            ->method('request')
+            ->will($this->returnCallback(function ($method, $uri, $options) use ($mockResponse) {
+                $this->capturedOptions = $options;
+                return $mockResponse;
+            }));
+
+        return new Client([
+            'url'      => 'https://example.com/',
+            'username' => 'test',
+            'password' => 'test',
+        ], $mockHttpClient);
     }
 }

--- a/test/ZammadAPIClient/EnvConfigTrait.php
+++ b/test/ZammadAPIClient/EnvConfigTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ZammadAPIClient;
+
+trait EnvConfigTrait
+{
+    private static function getZammadConfig(array $defaults = []): array
+    {
+        $config = $defaults;
+
+        $env_keys = [
+            'url'      => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL',
+            'username' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME',
+            'password' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD',
+        ];
+
+        foreach ($env_keys as $config_key => $env_key) {
+            $value = getenv($env_key);
+            if (empty($value)) {
+                throw new \RuntimeException("Missing environment variable $env_key");
+            }
+            $config[$config_key] = $value;
+        }
+
+        return $config;
+    }
+
+    private static function createZammadClient(array $extra_config = []): ?Client
+    {
+        try {
+            $config = self::getZammadConfig($extra_config);
+        }
+        catch (\RuntimeException $e) {
+            return null;
+        }
+
+        return new Client($config);
+    }
+}

--- a/test/ZammadAPIClient/Resource/AbstractBaseTest.php
+++ b/test/ZammadAPIClient/Resource/AbstractBaseTest.php
@@ -5,10 +5,13 @@ namespace ZammadAPIClient\Resource;
 use PHPUnit\Framework\TestCase;
 
 use ZammadAPIClient\Client;
+use ZammadAPIClient\EnvConfigTrait;
 use ZammadAPIClient\Exception\AlreadyFetchedObjectException;
 
 abstract class AbstractBaseTest extends TestCase
 {
+    use EnvConfigTrait;
+
     private static $client;
     protected $resource_type;
     protected static $created_objects = [];
@@ -17,25 +20,10 @@ abstract class AbstractBaseTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        $client_config = [
-            # Set a high timeout for tests to work with slow CI.
+        $client_config = self::getZammadConfig([
             'timeout' => 30,
-            'debug' => getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_DEBUG'),
-        ];
-
-        $env_keys = [
-            'url'      => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL',
-            'username' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME',
-            'password' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD',
-        ];
-        foreach ( $env_keys as $config_key => $env_key ) {
-            $value = getenv($env_key);
-            if ( empty($value) ) {
-                throw new \RuntimeException("Missing environment variable $env_key");
-            }
-
-            $client_config[$config_key] = $value;
-        }
+            'debug'   => getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_DEBUG'),
+        ]);
 
         self::$client = new Client($client_config);
     }


### PR DESCRIPTION
## What

Replaces the deprecated `X-On-Behalf-Of` HTTP header with `From` as required by Zammad >= 6.5.

## Why

In Zammad 6.5, using `X-On-Behalf-Of` causes a 500 Internal Server Error because the
deprecation warning itself crashes. Zammad now expects the standard `From` header.
The documentation has already been updated (zammad/zammad-documentation#626).

Closes #64.

## Changes

- **`src/Client.php`** — Header renamed from `X-On-Behalf-Of` to `From`
- **`README.md`** — Documentation updated to reference the `From` header
- **`CHANGELOG.md`** — Entry added

### Tests

- **`test/ZammadAPIClient/ClientTest.php`** — 3 new mock-based unit tests covering:
  - `From` header is set when `setOnBehalfOfUser()` is called
  - `From` header is absent by default
  - `From` header is removed after `unsetOnBehalfOfUser()`
  - 1 integration test (`testFromHeaderAgainstZammad`) that verifies the header works against a real Zammad instance (skipped when env vars are not configured)

- **`test/ZammadAPIClient/EnvConfigTrait.php`** — New trait providing `getZammadConfig()` and `createZammadClient()` to deduplicate environment-variable handling between `AbstractBaseTest` and `ClientTest`

- **`test/ZammadAPIClient/Resource/AbstractBaseTest.php`** — Refactored to use `EnvConfigTrait` instead of inline env-var logic

## Backward Compatibility

- Method names `setOnBehalfOfUser()` and `unsetOnBehalfOfUser()` remain unchanged
- `From` header is supported by Zammad pre-6.5 as well