### PR TITLE
Maintenance – Merge pr #59 && add integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Additionally you can have a look at the REST interface documentation of Zammad:
    * [Ticket priorities](https://docs.zammad.org/en/latest/api/ticket-priority.html)
    * [Ticket states](https://docs.zammad.org/en/latest/api/ticket-state.html)
 * [Tags](https://docs.zammad.org/en/latest/api/tags.html)
-* [Linking Tickets](https://docs.zammad.org/en/latest/api/ticket/links.html)
+ * [Tag list](https://docs.zammad.org/en/latest/api/ticket/tags.html#administration-scope)
+ * [Linking Tickets](https://docs.zammad.org/en/latest/api/ticket/links.html)
 
 #### Fetching a ticket's articles
 If you already have a ticket object, you can easily fetch its articles:
@@ -325,7 +326,7 @@ $client->resource( ResourceType::TICKET );
 | ORGANIZATION|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|&ndash;|&#10004;|
 | GROUP|&#10004;|&#10004;|&ndash;|&#10004;|&#10004;|&ndash;|&ndash;|&ndash;|
 | USER|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|&ndash;|&#10004;|
-| TAG|&#10004;|&ndash;|&#10004;|&ndash;|&ndash;|&#10004;|&#10004;|&ndash;|
+| TAG|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&#10004;|&ndash;|
 | LINK|&#10004;|&ndash;|&ndash;|&ndash;|&ndash;|&#10004;|&#10004;|&ndash;|
 
 ## Publishing

--- a/src/Resource/Tag.php
+++ b/src/Resource/Tag.php
@@ -13,7 +13,11 @@ class Tag extends AbstractResource
         'get'    => 'tags',
         'search' => 'tag_search?term={query}',
         'add'    => 'tags/add',
-        'remove' => 'tags/remove'
+        'remove' => 'tags/remove',
+        'all'    => 'tag_list',
+        'create' => 'tag_list',
+        'update' => 'tag_list/{object_id}',
+        'delete' => 'tag_list/{object_id}',
     ];
 
     /**

--- a/test/ZammadAPIClient/Resource/TagTest.php
+++ b/test/ZammadAPIClient/Resource/TagTest.php
@@ -135,6 +135,168 @@ class TagTest extends TestCase
         );
     }
 
+    public function testAdminAll()
+    {
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+
+        $this->assertIsArray(
+            $tags,
+            'all() must return an array.'
+        );
+
+        if ( count($tags) > 0 ) {
+            $tag = $tags[0];
+            $this->assertInstanceOf(
+                $this->resource_type,
+                $tag,
+                'Elements must be Tag instances.'
+            );
+            $this->assertNotNull(
+                $tag->getValue('id'),
+                'Tag must have an id field.'
+            );
+            $this->assertNotNull(
+                $tag->getValue('name'),
+                'Tag must have a name field.'
+            );
+        }
+    }
+
+    public function testAdminCreate()
+    {
+        $tag_name = self::getUniqueID();
+
+        $tag = self::getClient()->resource( $this->resource_type );
+        $tag->setValue('name', $tag_name);
+        $saved_tag = $tag->save();
+
+        $this->assertFalse(
+            $saved_tag->hasError(),
+            'Error must not be set after creating tag.'
+        );
+
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+        $found = false;
+        foreach ( $tags as $t ) {
+            if ( $t->getValue('name') === $tag_name ) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue(
+            $found,
+            'Created tag must appear in all().'
+        );
+    }
+
+    public function testAdminUpdate()
+    {
+        $tag_name = self::getUniqueID();
+
+        $tag = self::getClient()->resource( $this->resource_type );
+        $tag->setValue('name', $tag_name);
+        $tag->save();
+
+        $this->assertFalse(
+            $tag->hasError(),
+            'Error must not be set after creating tag for update.'
+        );
+
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+        $found_tag = null;
+        foreach ( $tags as $t ) {
+            if ( $t->getValue('name') === $tag_name ) {
+                $found_tag = $t;
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $found_tag,
+            'Created tag must be found in all().'
+        );
+
+        $new_name = $tag_name . '_updated';
+        $found_tag->setValue('name', $new_name);
+        $found_tag->save();
+
+        $this->assertFalse(
+            $found_tag->hasError(),
+            'Error must not be set after updating tag.'
+        );
+
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+        $found_updated = false;
+        $found_old = false;
+        foreach ( $tags as $t ) {
+            if ( $t->getValue('name') === $new_name ) {
+                $found_updated = true;
+            }
+            if ( $t->getValue('name') === $tag_name ) {
+                $found_old = true;
+            }
+        }
+
+        $this->assertTrue(
+            $found_updated,
+            'Updated tag name must appear in all().'
+        );
+        $this->assertFalse(
+            $found_old,
+            'Old tag name must not appear in all().'
+        );
+    }
+
+    public function testAdminDelete()
+    {
+        $tag_name = self::getUniqueID();
+
+        $tag = self::getClient()->resource( $this->resource_type );
+        $tag->setValue('name', $tag_name);
+        $tag->save();
+
+        $this->assertFalse(
+            $tag->hasError(),
+            'Error must not be set after creating tag for delete.'
+        );
+
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+        $found_tag = null;
+        foreach ( $tags as $t ) {
+            if ( $t->getValue('name') === $tag_name ) {
+                $found_tag = $t;
+                break;
+            }
+        }
+
+        $this->assertNotNull(
+            $found_tag,
+            'Created tag must be found in all() before delete.'
+        );
+
+        $found_tag->delete();
+
+        $this->assertFalse(
+            $found_tag->hasError(),
+            'Error must not be set after deleting tag.'
+        );
+
+        $tags = self::getClient()->resource( $this->resource_type )->all();
+        $found = false;
+        foreach ( $tags as $t ) {
+            if ( $t->getValue('name') === $tag_name ) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertFalse(
+            $found,
+            'Deleted tag must not appear in all().'
+        );
+    }
+
     private static function createTicket()
     {
         self::$ticket = self::getClient()->resource( ResourceType::TICKET );


### PR DESCRIPTION
Adds support for the Zammad Tag API administration scope: list, create, rename and delete tags globally via tag_list endpoints.

**Changes**
- src/Resource/Tag.php — Added all, create, update, delete URL definitions for admin scope (cherry-picked from #59 by @christopheg)
- README.md — Updated Tag feature row in the capability table and added admin scope documentation link
- test/ZammadAPIClient/Resource/TagTest.php — Added integration tests for all four admin operations
- examples/tag_admin.php — New example showing tag lifecycle: list → create → rename → delete

**How to test**
vendor/bin/phpunit --filter "TagTest::testAdmin"

Thanks to @christopheg for the original implementation in #59.