### PR TITLE
Maintenance – Added order by in search function

### DIFF
--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -387,7 +387,7 @@ abstract class AbstractResource
      * @return mixed                        Returns array of ZammadAPIClient\Resource\... objects
      *                                          or this object on failure.
      */
-    public function search( $search_term, $page = null, $objects_per_page = null )
+    public function search( $search_term, $page = null, $objects_per_page = null, $sort_by = null, $order_by = null )
     {
         if ( !empty( $this->getValues() ) ) {
             throw new AlreadyFetchedObjectException('Object already contains values, search() not possible, use a new object');
@@ -407,7 +407,7 @@ abstract class AbstractResource
         }
 
         if ( !isset($page) || !isset($objects_per_page) ) {
-            return $this->searchWithoutPagination($search_term);
+            return $this->searchWithoutPagination($search_term, $sort_by, $order_by);
         }
 
         $url_parameters = [
@@ -418,6 +418,13 @@ abstract class AbstractResource
         if ( isset($page) && isset($objects_per_page) ) {
             $url_parameters['page']     = $page;
             $url_parameters['per_page'] = $objects_per_page;
+        }
+
+        if ( isset($sort_by) ) {
+            $url_parameters['sort_by'] = $sort_by;
+        }
+        if ( isset($order_by) ) {
+            $url_parameters['order_by'] = $order_by;
         }
 
         $url      = $this->getURL('search');
@@ -453,7 +460,7 @@ abstract class AbstractResource
      * @return mixed                        Returns array of ZammadAPIClient\Resource\... objects
      *                                          or this object on failure.
      */
-    private function searchWithoutPagination($search_term)
+    private function searchWithoutPagination($search_term, $sort_by = null, $order_by = null)
     {
         $page             = 1;
         $objects_per_page = 100;
@@ -461,7 +468,7 @@ abstract class AbstractResource
         $objects_of_page  = [];
 
         do {
-            $objects_of_page = $this->search( $search_term, $page, $objects_per_page );
+            $objects_of_page = $this->search( $search_term, $page, $objects_per_page, $sort_by, $order_by );
             if ( !is_array($objects_of_page) ) {
                 return $this;
             }

--- a/src/Resource/AbstractResource.php
+++ b/src/Resource/AbstractResource.php
@@ -383,6 +383,8 @@ abstract class AbstractResource
      * @param string  $search_term          Search term.
      * @param integer $page                 Page of objects, optional, if given, $objects_per_page must also be given.
      * @param integer $objects_per_page     Number of objects per page, optional, if given, $page must also be given.
+     * @param string  $sort_by              Sort by field name, optional (e.g. 'created_at', 'title', 'number').
+     * @param string  $order_by             Sort order, optional, must be 'asc' or 'desc'.
      *
      * @return mixed                        Returns array of ZammadAPIClient\Resource\... objects
      *                                          or this object on failure.
@@ -404,6 +406,10 @@ abstract class AbstractResource
             || ( !isset($page) && isset($objects_per_page) )
         ) {
             throw new \RuntimeException('Parameters page and objects_per_page must both be given');
+        }
+
+        if ( isset($order_by) && !in_array( mb_strtolower($order_by), [ 'asc', 'desc' ] ) ) {
+            throw new \RuntimeException('Parameter order_by must be "asc" or "desc"');
         }
 
         if ( !isset($page) || !isset($objects_per_page) ) {
@@ -456,6 +462,10 @@ abstract class AbstractResource
      * Fetches object data for searched objects of this type.
      * This method will be used internally and automatically by search() to automate pagination
      * to retrieve all available objects, ignoring the server side limit of fetchable objects.
+     *
+     * @param string $search_term          Search term.
+     * @param string $sort_by              Sort by field name, optional.
+     * @param string $order_by             Sort order, optional.
      *
      * @return mixed                        Returns array of ZammadAPIClient\Resource\... objects
      *                                          or this object on failure.

--- a/src/Resource/Tag.php
+++ b/src/Resource/Tag.php
@@ -101,7 +101,7 @@ class Tag extends AbstractResource
      * @return mixed                        Returns array of ZammadAPIClient\Resource\... objects
      *                                          or this object on failure.
      */
-    public function search($search_term, $page = null, $objects_per_page = null)
+    public function search($search_term, $page = null, $objects_per_page = null, $sort_by = null, $order_by = null)
     {
         $this->clearError();
 


### PR DESCRIPTION
#Added sort_by and order_by parameters to search()

Based on #43 by @mostafaqanbaryan — thanks for the initial contribution!

### References
- [Zammad REST API — Search via API](https://docs.zammad.org/en/latest/api/intro.html#search-via-api)

### What it does
Adds sort_by and order_by as optional parameters to Resource\AbstractResource::search(), allowing search results to be sorted server-side via the Zammad REST API:
```php
$tickets = $client->resource(ResourceType::TICKET)->search(
    'my query',
    null,           // page (auto-paginate)
    null,           // per_page
    'created_at',   // sort_by
    'desc'          // order_by
);
```

### Changes
- `search()` and `searchWithoutPagination()` both accept `$sort_by` and `$order_by` as optional parameters (backwards compatible)
- `$order_by` validated — must be "asc" or "desc", `throws \RuntimeException` otherwise
- `Tag::search()` signature updated for parent class compatibility
- Full PHPDoc coverage for all new parameters

### Thanks
@mostafaqanbaryan for the original PR #43