### PR TITLE
Give LinkTest and TagTest the same generous HTTP timeout as AbstractBaseTest

### DIFF
--- a/test/ZammadAPIClient/Resource/LinkTest.php
+++ b/test/ZammadAPIClient/Resource/LinkTest.php
@@ -4,31 +4,28 @@ namespace ZammadAPIClient\Resource;
 
 use PHPUnit\Framework\TestCase;
 use ZammadAPIClient\Client;
+use ZammadAPIClient\EnvConfigTrait;
 use ZammadAPIClient\ResourceType;
 
 class LinkTest extends TestCase
 {
+    use EnvConfigTrait;
+
     private static $client;
     private static $source_ticket;
     private static $target_ticket;
 
     public static function setUpBeforeClass(): void
     {
-        $client_config = [];
+        // This suite creates and deletes real tickets (with their articles, links,
+        // etc.) for every single test, which can occasionally take longer than the
+        // client's 5 second default timeout under load. Match AbstractBaseTest's
+        // more generous timeout to avoid spurious ConnectExceptions in tearDown().
+        $client_timeout = getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT');
 
-        $env_keys = [
-            'url'      => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL',
-            'username' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME',
-            'password' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD',
-        ];
-        foreach ( $env_keys as $config_key => $env_key ) {
-            $value = getenv( $env_key );
-            if ( empty($value) ) {
-                throw new \RuntimeException("Missing environment variable $env_key");
-            }
-
-            $client_config[$config_key] = $value;
-        }
+        $client_config = self::getZammadConfig([
+            'timeout' => !empty($client_timeout) ? $client_timeout : 30,
+        ]);
 
         self::$client = new Client($client_config);
     }

--- a/test/ZammadAPIClient/Resource/TagTest.php
+++ b/test/ZammadAPIClient/Resource/TagTest.php
@@ -4,10 +4,13 @@ namespace ZammadAPIClient\Resource;
 
 use PHPUnit\Framework\TestCase;
 use ZammadAPIClient\Client;
+use ZammadAPIClient\EnvConfigTrait;
 use ZammadAPIClient\ResourceType;
 
 class TagTest extends TestCase
 {
+    use EnvConfigTrait;
+
     private static $client;
     private static $ticket;
 
@@ -15,21 +18,15 @@ class TagTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        $client_config = [];
+        // This suite creates and deletes a real ticket for every single test, which
+        // can occasionally take longer than the client's 5 second default timeout
+        // under load. Match AbstractBaseTest's more generous timeout to avoid
+        // spurious ConnectExceptions in tearDown().
+        $client_timeout = getenv('ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT');
 
-        $env_keys = [
-            'url'      => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_URL',
-            'username' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_USERNAME',
-            'password' => 'ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_PASSWORD',
-        ];
-        foreach ( $env_keys as $config_key => $env_key ) {
-            $value = getenv($env_key);
-            if ( empty($value) ) {
-                throw new \RuntimeException("Missing environment variable $env_key");
-            }
-
-            $client_config[$config_key] = $value;
-        }
+        $client_config = self::getZammadConfig([
+            'timeout' => !empty($client_timeout) ? $client_timeout : 30,
+        ]);
 
         self::$client = new Client($client_config);
     }


### PR DESCRIPTION
## Summary
- `LinkTest` and `TagTest` create and delete real tickets (with articles, links, etc.) for every single test, but their `setUpBeforeClass()` predates `EnvConfigTrait`/`AbstractBaseTest` and never overrides the client's 5 second default HTTP timeout.
- Under load, ticket deletion cascades through enough related records that it can occasionally exceed 5 seconds, causing a `ConnectException` in `tearDown()` that gets misattributed to whatever test happened to be running at the time (observed as e.g. `LinkTest::testRemoveWithoutTargetTicket` failing with a cURL timeout on a `DELETE .../tickets/:id` call, even though that test's own assertion doesn't touch the network at all).
- `AbstractBaseTest` already fixed this for the test classes that extend it, by bumping the timeout to 30 seconds (configurable via `ZAMMAD_PHP_API_CLIENT_UNIT_TESTS_TIMEOUT`). This PR just brings `LinkTest` and `TagTest` in line with that existing convention.

## Test plan
- [x] CI run of the full test suite should pass as before, just with a more generous timeout available for the create/delete-heavy `LinkTest`/`TagTest` fixtures.