### PR TITLE
Fix: send Accept: application/json header on all requests (#157)

### DIFF
--- a/src/Core/Transport/RequestHandler.php
+++ b/src/Core/Transport/RequestHandler.php
@@ -217,7 +217,8 @@ final class RequestHandler implements RequestHandlerInterface
         $this->logger->debug("Zammad API request: {$method} {$fullUri}");
 
         try {
-            $request = $this->requestFactory->createRequest($method, $fullUri);
+            $request = $this->requestFactory->createRequest($method, $fullUri)
+                ->withHeader('Accept', 'application/json');
 
             if (isset($options['headers']) && is_array($options['headers'])) {
                 foreach ($options['headers'] as $name => $value) {

--- a/test/Unit/Core/RequestHandlerTest.php
+++ b/test/Unit/Core/RequestHandlerTest.php
@@ -167,6 +167,26 @@ final class RequestHandlerTest extends TestCase
         self::assertNotNull($this->handler->getLastResponse());
     }
 
+    public function testRequestsSendAcceptJsonHeader(): void
+    {
+        $this->httpClient->response = new Response(200, [], '{}');
+
+        $this->handler->get('tickets');
+
+        self::assertNotNull($this->httpClient->lastRequest);
+        self::assertSame('application/json', $this->httpClient->lastRequest->getHeaderLine('Accept'));
+    }
+
+    public function testRequestsSendAcceptJsonHeaderOnPost(): void
+    {
+        $this->httpClient->response = new Response(201, [], '{}');
+
+        $this->handler->post('tickets', ['title' => 'x']);
+
+        self::assertNotNull($this->httpClient->lastRequest);
+        self::assertSame('application/json', $this->httpClient->lastRequest->getHeaderLine('Accept'));
+    }
+
     public function testGetRawWithQueryParamsAppendsToUri(): void
     {
         $this->httpClient->response = new Response(200, [], 'binary');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Outgoing requests now include an `Accept: application/json` header by default.
  - Custom request headers can still override the default value.

- **Tests**
  - Added coverage confirming the header is included for GET and POST requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->